### PR TITLE
Basemapper: Allow for in memory BytesIO GeoJSON for boundary param

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -21,6 +21,7 @@
 
 import argparse
 import concurrent.futures
+from io import BytesIO
 import logging
 import queue
 import re
@@ -45,6 +46,7 @@ from pmtiles.writer import Writer as PMTileWriter
 from pySmartDL import SmartDL
 from shapely.geometry import shape
 from shapely.ops import unary_union
+from osm_fieldwork.boundary_handler_factory import BoundaryHandlerFactory
 
 from osm_fieldwork.sqlite import DataFile, MapTile
 from osm_fieldwork.xlsforms import xlsforms_path
@@ -125,7 +127,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: str,
+        boundary: Union[str, BytesIO],
         base: str,
         source: str,
         xy: bool,
@@ -133,7 +135,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (str): A BBOX string or GeoJSON file of the AOI.
+            boundary (Union[str, BytesIO]): A BBOX string or GeoJSON provided as BytesIO object of the AOI.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -142,7 +144,8 @@ class BaseMapper(object):
         Returns:
             (BaseMapper): An instance of this class
         """
-        self.bbox = self.makeBbox(boundary)
+        bbox_factory = BoundaryHandlerFactory(boundary)
+        self.bbox = bbox_factory.get_bounding_box()
         self.tiles = list()
         self.base = base
         # sources for imagery
@@ -270,66 +273,6 @@ class BaseMapper(object):
             log.debug("%s doesn't exists" % filespec)
             return False
 
-    def makeBbox(
-        self,
-        boundary: str,
-    ) -> tuple[float, float, float, float]:
-        """Make a bounding box from a shapely geometry.
-
-        Args:
-            boundary (str): A BBOX string or GeoJSON file of the AOI.
-                The GeoJSON can contain multiple geometries.
-
-        Returns:
-            (list): The bounding box coordinates
-        """
-        if not boundary.lower().endswith((".json", ".geojson")):
-            # Is BBOX string
-            try:
-                if "," in boundary:
-                    bbox_parts = boundary.split(",")
-                else:
-                    bbox_parts = boundary.split(" ")
-                bbox = tuple(float(x) for x in bbox_parts)
-                if len(bbox) == 4:
-                    # BBOX valid
-                    return bbox
-                else:
-                    msg = f"BBOX string malformed: {bbox}"
-                    log.error(msg)
-                    raise ValueError(msg) from None
-            except Exception as e:
-                log.error(e)
-                msg = f"Failed to parse BBOX string: {boundary}"
-                log.error(msg)
-                raise ValueError(msg) from None
-
-        log.debug(f"Reading geojson file: {boundary}")
-        with open(boundary, "r") as f:
-            poly = geojson.load(f)
-        if "features" in poly:
-            geometry = shape(poly["features"][0]["geometry"])
-        elif "geometry" in poly:
-            geometry = shape(poly["geometry"])
-        else:
-            geometry = shape(poly)
-
-        if isinstance(geometry, list):
-            # Multiple geometries
-            log.debug("Creating union of multiple bbox geoms")
-            geometry = unary_union(geometry)
-
-        if geometry.is_empty:
-            msg = f"No bbox extracted from {geometry}"
-            log.error(msg)
-            raise ValueError(msg) from None
-
-        bbox = geometry.bounds
-        # left, bottom, right, top
-        # minX, minY, maxX, maxY
-        return bbox
-
-
 def tileid_from_y_tile(filepath: Union[Path | str]):
     """Helper function to get the tile id from a tile in z/x/y directory structure.
 
@@ -420,7 +363,7 @@ def create_basemap_file(
 
     Args:
         verbose (bool, optional): Enable verbose output if True.
-        boundary (str, optional): The boundary for the area you want.
+        boundary (str | BytesIO, optional): The boundary for the area you want.
         tms (str, optional): Custom TMS URL.
         xy (bool, optional): Swap the X & Y coordinates when using a
             custom TMS if True.
@@ -456,7 +399,7 @@ def create_basemap_file(
 
     # Validation
     if not boundary:
-        err = "You need to specify a boundary! (file or bbox)"
+        err = "You need to specify a boundary! (in-memory object or bbox)"
         log.error(err)
         raise ValueError(err)
 
@@ -576,7 +519,9 @@ def main():
             log.error("")
             parser.print_help()
             quit()
-        boundary_parsed = args.boundary[0]
+        with open(Path(args.boundary[0]), "rb") as geojson_file:
+            boundary = geojson_file.read()
+            boundary_parsed = BytesIO(boundary)
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)
     else:

--- a/osm_fieldwork/boundary_handler_factory.py
+++ b/osm_fieldwork/boundary_handler_factory.py
@@ -1,0 +1,26 @@
+from typing import Union
+from io import BytesIO
+from .boundary_handlers import BoundingBox, BytesIOBoundaryHandler, StringBoundaryHandler
+
+"""
+Boundary Handler Factory
+
+This module provides a factory class for creating boundary handlers based on the type of input boundary provided. It supports boundary inputs represented either as GeoJSON files, GeoJSON data, or BBOX strings.
+
+Classes:
+- BoundaryHandlerFactory: Factory class for creating boundary handlers.
+"""
+
+class BoundaryHandlerFactory:
+    def __init__(self, boundary: Union[str, BytesIO]):
+        if isinstance(boundary, BytesIO):
+            self.handler = BytesIOBoundaryHandler(boundary)
+        elif isinstance(boundary, str):
+            self.handler = StringBoundaryHandler(boundary)
+        else:
+            raise ValueError("Unsupported type for boundary parameter.")
+
+        self.boundary_box = self.handler.make_bbox()
+
+    def get_bounding_box(self) -> BoundingBox:
+        return self.boundary_box

--- a/osm_fieldwork/boundary_handler_factory.py
+++ b/osm_fieldwork/boundary_handler_factory.py
@@ -5,7 +5,8 @@ from .boundary_handlers import BoundingBox, BytesIOBoundaryHandler, StringBounda
 """
 Boundary Handler Factory
 
-This module provides a factory class for creating boundary handlers based on the type of input boundary provided. It supports boundary inputs represented either as GeoJSON files, GeoJSON data, or BBOX strings.
+This module provides a factory class for creating boundary handlers based on the type of input boundary provided.
+It supports boundary inputs represented either as GeoJSON files wrapped in BytesIO, or BBOX strings.
 
 Classes:
 - BoundaryHandlerFactory: Factory class for creating boundary handlers.

--- a/osm_fieldwork/boundary_handlers.py
+++ b/osm_fieldwork/boundary_handlers.py
@@ -12,12 +12,12 @@ BoundingBox = Tuple[float, float, float, float]
 """
 Boundary Handlers for Bounding Box (BBOX) Extraction
 
-This module provides classes to extract Bounding Box (BBOX) coordinates from various boundary representations, 
-including GeoJSON files, GeoJSON data, and BBOX strings.
+This module provides classes to extract Bounding Box (BBOX) from various boundary representations,
+including GeoJSON files wrapped in BytesIO object, and BBOX strings.
 
 Classes:
 - BytesIOBoundaryHandler: Extracts BBOX from GeoJSON data stored in a BytesIO object.
-- StringBoundaryHandler: Extracts BBOX from a BBOX string representation.
+- StringBoundaryHandler: Extracts BBOX from string representation.
 """
 class BoundaryHandler:
     def make_bbox(self) -> BoundingBox:

--- a/osm_fieldwork/boundary_handlers.py
+++ b/osm_fieldwork/boundary_handlers.py
@@ -1,0 +1,81 @@
+from typing import Union, Tuple
+import logging
+from io import BytesIO
+import geojson
+from shapely.geometry import shape
+from shapely.ops import unary_union
+
+log = logging.getLogger(__name__)
+
+BoundingBox = Tuple[float, float, float, float]
+
+"""
+Boundary Handlers for Bounding Box (BBOX) Extraction
+
+This module provides classes to extract Bounding Box (BBOX) coordinates from various boundary representations, 
+including GeoJSON files, GeoJSON data, and BBOX strings.
+
+Classes:
+- BytesIOBoundaryHandler: Extracts BBOX from GeoJSON data stored in a BytesIO object.
+- StringBoundaryHandler: Extracts BBOX from a BBOX string representation.
+"""
+class BoundaryHandler:
+    def make_bbox(self) -> BoundingBox:
+        pass
+
+class BytesIOBoundaryHandler(BoundaryHandler):
+    def __init__(self, boundary: BytesIO):
+        self.boundary = boundary
+
+    def make_bbox(self) -> BoundingBox:
+        log.debug(f"Reading geojson BytesIO : {self.boundary}")
+        # Rewind the BytesIO object to the beginning before passing it to geojson.load()
+        self.boundary.seek(0)
+        with self.boundary as buffer:
+            poly = geojson.load(buffer)
+
+        if "features" in poly:
+            geometry = shape(poly["features"][0]["geometry"])
+        elif "geometry" in poly:
+            geometry = shape(poly["geometry"])
+        else:
+            geometry = shape(poly)
+
+        if isinstance(geometry, list):
+            # Multiple geometries
+            log.debug("Creating union of multiple bbox geoms")
+            geometry = unary_union(geometry)
+
+        if geometry.is_empty:
+            msg = f"No bbox extracted from {geometry}"
+            log.error(msg)
+            raise ValueError(msg) from None
+
+        bbox = geometry.bounds
+        # left, bottom, right, top
+        # minX, minY, maxX, maxY
+        return bbox
+
+class StringBoundaryHandler(BoundaryHandler):
+    def __init__(self, boundary: str):
+        self.boundary = boundary
+
+    def make_bbox(self) -> BoundingBox:
+        try:
+            if "," in self.boundary:
+                bbox_parts = self.boundary.split(",")
+            else:
+                bbox_parts = self.boundary.split(" ")
+            bbox = tuple(float(x) for x in bbox_parts)
+            if len(bbox) == 4:
+                # BBOX valid
+                return bbox
+            else:
+                msg = f"BBOX string malformed: {bbox}"
+                log.error(msg)
+                raise ValueError(msg) from None
+        except Exception as e:
+            log.error(e)
+            msg = f"Failed to parse BBOX string: {self.boundary}"
+            log.error(msg)
+            raise ValueError(msg) from None

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,9 +1,0 @@
-from osm_fieldwork.basemapper import create_basemap_file
-
-create_basemap_file(
-    verbose=True,
-    boundary="-4.730494,41.650541,-4.725634,41.652874",
-    outfile="outreachy.mbtiles",
-    zooms="12-19",
-    source="esri",
-)

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,9 @@
+from osm_fieldwork.basemapper import create_basemap_file
+
+create_basemap_file(
+    verbose=True,
+    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    outfile="outreachy.mbtiles",
+    zooms="12-19",
+    source="esri",
+)

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -19,9 +19,13 @@
 #
 """Test functionalty of basemapper.py."""
 
+from io import BytesIO
 import logging
 import os
 import shutil
+import pytest
+from pathlib import Path
+
 
 from osm_fieldwork.basemapper import BaseMapper
 from osm_fieldwork.sqlite import DataFile
@@ -29,7 +33,10 @@ from osm_fieldwork.sqlite import DataFile
 log = logging.getLogger(__name__)
 
 rootdir = os.path.dirname(os.path.abspath(__file__))
-boundary = f"{rootdir}/testdata/Rollinsville.geojson"
+string_boundary = "-105.642662 39.917580 -105.631343 39.929250"
+with open(Path(f"{rootdir}/testdata/Rollinsville.geojson"), "rb") as geojson_file:
+    boundary = geojson_file.read()
+    object_boundary = BytesIO(boundary)
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
 # boundary = open(infile, "r")
@@ -42,7 +49,8 @@ base = "./tiles"
 #    geometry = shape(poly)
 
 
-def test_create():
+@pytest.mark.parametrize("boundary", [string_boundary, object_boundary])
+def test_create(boundary):
     """See if the file got loaded."""
     hits = 0
     basemap = BaseMapper(boundary, base, "topo", False)


### PR DESCRIPTION
### Context
* In memory GeoJSON should be the default format for bbox passing, with additional support for bbox string format.
* The support for parsing GeoJSON files on disk should ideally be removed from the BaseMapper class and placed inside the `main()` function that is only used when running `basemapper` via the command line. The file should be read and converted to `BytesIO` object, before passing through to the `create_basemap_file` function.

### What was done in this PR?
1. Refactored entrypoint `main()` function of `basemapper.py`, by converting GeoJSON file to object(`BytesIO`), before sending it to `create_basemap_file`
2. Added in-memory object(`BytesIO`) support for `BaseMapper` class
2.1 Applied single responsibility principle by moving code related to creation of bounding box to factory object, that delegates creation of bbox to appropriate handlers 
2.2. Created `BytesIO Handler` that is responsible for making bbox for BytesIO objects
2.3. Created `String Handler` that is responsible for making bbox for String types
2.4. Removed support for GeoJSON file, since it was decided that `create_basemap_file` function that creates `BaseMapper` will receive GeoJSON already wrapped in BytesIO object.
3. Extended `test_basemap.php` to cover both string and file-input use cases, by using method level data provider.

### Test plan
1. Manually run following scripts, which successfully generated MBTiles:
```
pdm run python osm_fieldwork/basemapper.py -b -4.730494 41.650541 -4.725634 41.652874 -z 12-15 -s esri
pdm run python osm_fieldwork/basemapper.py -b input_file.geojson -z 12-15 -s esri
```
2. PyTest testing:
`docker compose run --rm fieldwork pytest tests/test_basemap.py`

Attached the screen of successful test run.
<img width="1207" alt="Screenshot 2024-03-10 at 02 53 45" src="https://github.com/azharcodeit/osm-fieldwork/assets/31756707/28624377-d15b-4139-a751-733c05c0ec11">
